### PR TITLE
Lenient linear solver

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 FrankWolfe = "f55ce6ea-fdc5-4628-88c5-0087fe54bd30"
+ImplicitDifferentiation = "57b37032-215b-411a-8a7c-41a003a55207"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -29,4 +30,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "ChainRulesCore", "Documenter", "ForwardDiff", "FrankWolfe", "JET", "JuliaFormatter", "Random", "Statistics", "Test", "Zygote"]
+test = ["Aqua", "ChainRulesCore", "Documenter", "ForwardDiff", "FrankWolfe", "ImplicitDifferentiation", "JET", "JuliaFormatter", "Random", "Statistics", "Test", "Zygote"]

--- a/src/DifferentiableFrankWolfe.jl
+++ b/src/DifferentiableFrankWolfe.jl
@@ -12,6 +12,8 @@ using ImplicitDifferentiation: ImplicitFunction, IterativeLinearSolver
 using LinearAlgebra: dot
 
 export DiffFW
+export LinearMinimizationOracle, compute_extreme_point  # from FrankWolfe
+export IterativeLinearSolver  # from ImplicitDifferentiation
 
 include("simplex_projection.jl")
 include("difffw.jl")

--- a/src/DifferentiableFrankWolfe.jl
+++ b/src/DifferentiableFrankWolfe.jl
@@ -8,7 +8,7 @@ module DifferentiableFrankWolfe
 using ChainRulesCore: ChainRulesCore, NoTangent
 using FrankWolfe: FrankWolfe, LinearMinimizationOracle
 using FrankWolfe: away_frank_wolfe, compute_extreme_point
-using ImplicitDifferentiation: ImplicitFunction
+using ImplicitDifferentiation: ImplicitFunction, IterativeLinearSolver
 using LinearAlgebra: dot
 
 export DiffFW

--- a/src/difffw.jl
+++ b/src/difffw.jl
@@ -52,6 +52,16 @@ Constructor which chooses a default algorithm and creates the implicit function 
 function DiffFW(f, f_grad1, lmo; alg=away_frank_wolfe, implicit_kwargs=NamedTuple())
     forward = ForwardFW(f, f_grad1, lmo, alg)
     conditions = ConditionsFW(f_grad1)
+    if !haskey(implicit_kwargs, :linear_solver)
+        implicit_kwargs = merge(
+            implicit_kwargs,
+            (;
+                linear_solver=IterativeLinearSolver(;
+                    verbose=true, accept_inconsistent=true
+                )
+            ),
+        )
+    end
     implicit = ImplicitFunction(forward, conditions; implicit_kwargs...)
     return DiffFW(f, f_grad1, lmo, alg, implicit)
 end

--- a/src/difffw.jl
+++ b/src/difffw.jl
@@ -52,16 +52,6 @@ Constructor which chooses a default algorithm and creates the implicit function 
 function DiffFW(f, f_grad1, lmo; alg=away_frank_wolfe, implicit_kwargs=NamedTuple())
     forward = ForwardFW(f, f_grad1, lmo, alg)
     conditions = ConditionsFW(f_grad1)
-    if !haskey(implicit_kwargs, :linear_solver)
-        implicit_kwargs = merge(
-            implicit_kwargs,
-            (;
-                linear_solver=IterativeLinearSolver(;
-                    verbose=true, accept_inconsistent=true
-                )
-            ),
-        )
-    end
     implicit = ImplicitFunction(forward, conditions; implicit_kwargs...)
     return DiffFW(f, f_grad1, lmo, alg, implicit)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Aqua
 using DifferentiableFrankWolfe
 using Documenter
+using ImplicitDifferentiation
 using JET
 using JuliaFormatter
 using Test
@@ -27,5 +28,10 @@ using Zygote
 
     @testset "Tutorial" begin
         include(joinpath(@__DIR__, "..", "examples", "tutorial.jl"))
+    end
+
+    @testset "Constructor" begin
+        dfw = DiffFW(f, f_grad1, lmo)
+        @test dfw.implicit.linear_solver.accept_inconsistent
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,7 +31,13 @@ using Zygote
     end
 
     @testset "Constructor" begin
-        dfw = DiffFW(f, f_grad1, lmo)
-        @test dfw.implicit.linear_solver.accept_inconsistent
+        dfw1 = DiffFW(f, f_grad1, lmo)
+        @test !dfw1.implicit.linear_solver.accept_inconsistent
+
+        implicit_kwargs = (;
+            linear_solver=IterativeLinearSolver(; accept_inconsistent=true)
+        )
+        dfw2 = DiffFW(f, f_grad1, lmo; implicit_kwargs)
+        @test dfw2.implicit.linear_solver.accept_inconsistent
     end
 end


### PR DESCRIPTION
Re-export utilities from ImplicitDifferentiation.jl and FrankWolfe.jl that are useful for InferOpt.jl.

This makes sense because otherwise there would be 3 conditional dependencies required to load the InferOptFrankWolfeExt extension