### PR TITLE
Update to ImplicitDifferentiation v0.6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.6', '1']
+        version: ['1.10', 'pre']
         os: [ubuntu-latest]
         arch: [x64]
         allow_failure: [false]
@@ -27,7 +27,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiableFrankWolfe"
 uuid = "b383313e-5450-4164-a800-befbd27b574d"
 authors = ["Guillaume Dalle"]
-version = "0.2.1"
+version = "0.3.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -12,9 +12,9 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 [compat]
 ChainRulesCore = "1.15"
 FrankWolfe = "0.3"
-ImplicitDifferentiation = "0.5"
+ImplicitDifferentiation = "0.6"
 LinearAlgebra = "1"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/src/DifferentiableFrankWolfe.jl
+++ b/src/DifferentiableFrankWolfe.jl
@@ -5,15 +5,13 @@ Differentiable wrapper for [FrankWolfe.jl](https://github.com/ZIB-IOL/FrankWolfe
 """
 module DifferentiableFrankWolfe
 
-using ChainRulesCore: ChainRulesCore, NoTangent
+using ChainRulesCore: ChainRulesCore, NoTangent, ProjectTo, unthunk
 using FrankWolfe: FrankWolfe, LinearMinimizationOracle
 using FrankWolfe: away_frank_wolfe, compute_extreme_point
-using ImplicitDifferentiation: ImplicitFunction, IterativeLinearSolver
+using ImplicitDifferentiation: ImplicitFunction
 using LinearAlgebra: dot
 
 export DiffFW
-export LinearMinimizationOracle, compute_extreme_point  # from FrankWolfe
-export IterativeLinearSolver  # from ImplicitDifferentiation
 
 include("simplex_projection.jl")
 include("difffw.jl")

--- a/src/difffw.jl
+++ b/src/difffw.jl
@@ -55,17 +55,17 @@ function DiffFW(f, f_grad1, lmo; alg=away_frank_wolfe, implicit_kwargs=NamedTupl
 end
 
 """
-    dfw(θ; frank_wolfe_kwargs)
+    dfw(θ::AbstractVector; frank_wolfe_kwargs)
 
 Apply the Frank-Wolfe algorithm to `θ` with settings defined by `frank_wolfe_kwargs`.
 """
-function (dfw::DiffFW)(θ::AbstractArray{<:Real}; kwargs...)
+function (dfw::DiffFW)(θ::AbstractVector{<:Real}; kwargs...)
     p, V = dfw.implicit(θ; kwargs...)
     return sum(pᵢ * Vᵢ for (pᵢ, Vᵢ) in zip(p, V))
 end
 
 function (forward::ForwardFW)(
-    θ::AbstractArray{<:Real}; frank_wolfe_kwargs=NamedTuple(), kwargs...
+    θ::AbstractVector{<:Real}; frank_wolfe_kwargs=NamedTuple(), kwargs...
 )
     f, f_grad1, lmo, alg = forward.f, forward.f_grad1, forward.lmo, forward.alg
     obj(x) = f(x, θ)
@@ -79,9 +79,9 @@ function (forward::ForwardFW)(
 end
 
 function (conditions::ConditionsFW)(
-    θ::AbstractArray{<:Real},
+    θ::AbstractVector{<:Real},
     p::AbstractVector{<:Real},
-    V::AbstractVector{<:AbstractArray{<:Real}};
+    V::AbstractVector{<:AbstractVector{<:Real}};
     kwargs...,
 )
     f_grad1 = conditions.f_grad1

--- a/src/simplex_projection.jl
+++ b/src/simplex_projection.jl
@@ -32,11 +32,13 @@ function simplex_projection_and_support(z::AbstractVector{<:Real})
 end
 
 function ChainRulesCore.rrule(::typeof(simplex_projection), z::AbstractVector{<:Real})
+    proj = ProjectTo(z)
     p, s = simplex_projection_and_support(z)
     S = sum(s)
-    function simplex_projection_pullback(dp)
+    function simplex_projection_pullback(dp_thunked)
+        dp = unthunk(dp_thunked)
         vjp = s .* (dp .- dot(dp, s) / S)
-        return (NoTangent(), vjp)
+        return (NoTangent(), proj(vjp))
     end
     return p, simplex_projection_pullback
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,9 +19,7 @@ using Zygote
     end
 
     @testset "Correctness (JET.jl)" begin
-        if VERSION >= v"1.9"
-            JET.test_package(DifferentiableFrankWolfe; target_defined_modules=true)
-        end
+        JET.test_package(DifferentiableFrankWolfe; target_defined_modules=true)
     end
 
     @testset "Doctests (Documenter.jl)" begin
@@ -34,12 +32,10 @@ using Zygote
 
     @testset "Constructor" begin
         dfw1 = DiffFW(f, f_grad1, lmo)
-        @test !dfw1.implicit.linear_solver.accept_inconsistent
+        @test dfw1.implicit.linear_solver != \
 
-        implicit_kwargs = (;
-            linear_solver=IterativeLinearSolver(; accept_inconsistent=true)
-        )
+        implicit_kwargs = (; linear_solver=\)
         dfw2 = DiffFW(f, f_grad1, lmo; implicit_kwargs)
-        @test dfw2.implicit.linear_solver.accept_inconsistent
+        @test dfw2.implicit.linear_solver == \
     end
 end


### PR DESCRIPTION
- Bumped version to v0.3.0

**BREAKING**

- Update to ImplicitDifferentiation v0.6
- Only vectors are supported, no general arrays
- The keywords passed to the `ImplicitFunction` object have changed
- Remove exports except DiffFW

**NON-BREAKING**

- Bumped Julia compat to 1.10 (dropped 1.6)