### PR TITLE
Update and speed up

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,21 +12,16 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        version: ['1.10', 'pre']
-        os: [ubuntu-latest]
-        arch: [x64]
-        allow_failure: [false]
+        version: ['1.10', '1']
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
@@ -37,7 +32,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
   docs:
-    name: Documentation
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiableFrankWolfe"
 uuid = "b383313e-5450-4164-a800-befbd27b574d"
 authors = ["Guillaume Dalle"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -12,7 +12,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 [compat]
 ChainRulesCore = "1.15"
 FrankWolfe = "0.3, 0.4"
-ImplicitDifferentiation = "0.6"
+ImplicitDifferentiation = "0.7"
 LinearAlgebra = "1"
 julia = "1.10"
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,18 +6,16 @@ CurrentModule = DifferentiableFrankWolfe
 
 Documentation for [DifferentiableFrankWolfe.jl](https://github.com/gdalle/DifferentiableFrankWolfe.jl).
 
-## Index
+## Public API
 
-```@index
+```@autodocs
+Modules = [DifferentiableFrankWolfe]
+Private = false
 ```
 
-## API reference
+## Private API
 
-```@docs
-DifferentiableFrankWolfe
-DiffFW
-simplex_projection
-simplex_projection_and_support
-ForwardFW
-ConditionsFW
+```@autodocs
+Modules = [DifferentiableFrankWolfe]
+Public = false
 ```

--- a/examples/tutorial.jl
+++ b/examples/tutorial.jl
@@ -21,8 +21,9 @@ dfw = DiffFW(f, f_grad1, lmo);  # ... is equivalent to a simplex projection
 
 #-
 
-frank_wolfe_kwargs = (max_iteration=100, epsilon=1e-4)
-y = dfw(θ; frank_wolfe_kwargs)
+frank_wolfe_kwargs = (; max_iteration=100, epsilon=1e-4)
+y, stats = dfw(θ, frank_wolfe_kwargs)
+y
 
 #-
 
@@ -31,12 +32,12 @@ y_true = simplex_projection(θ)
 
 # Differentiating the wrapper
 
-J1 = Zygote.jacobian(_θ -> dfw(_θ; frank_wolfe_kwargs), θ)[1]
+J1 = Zygote.jacobian(_θ -> dfw(_θ, frank_wolfe_kwargs)[1], θ)[1]
 J1_true = Zygote.jacobian(simplex_projection, θ)[1]
 @test J1 ≈ J1_true atol = 1e-3
 
 #-
 
-J2 = ForwardDiff.jacobian(_θ -> dfw(_θ; frank_wolfe_kwargs), θ)
+J2 = ForwardDiff.jacobian(_θ -> dfw(_θ, frank_wolfe_kwargs)[1], θ)
 J2_true = ForwardDiff.jacobian(simplex_projection, θ)
 @test J2 ≈ J2_true atol = 1e-3


### PR DESCRIPTION
## Breaking changes

- Make `dfw(theta)` return a couple `(x, stats)` instead of just the solution `x`
- Pass `alg` and `frank_wolfe_kwargs` as positional arguments to their respective functions
- Remove everything from public API except `DiffFW`

## Other changes

- Bump ImplicitDifferentiation compat to v0.7